### PR TITLE
Fix #2 Do not require local figwheel-bridge.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,32 @@ clj -R:repl -m clj-rn.main rebuild-index --help
 
 ```
 $ clj -R:repl -m clj-rn.main rebuild-index -p android,ios -a genymotion -i real --figwheel-port 3456
+
 ```
+
+### Upgrading from an existing project
+
+- If your existing project has a `figwheel-bridge.js` in the root directory, it can be deleted now as `figwheel` task of `clj-rn.main` would create it for you and place it in `target` directory, it is being required by `index.*.js` every time when starting the app with figwheel. Alternatively, you can choose to use your own JS bridge by setting a variable named `:figwheel-bridge` in `clj-rn.conf.edn`, the value should be that of the JS module name. e.g. `./resources/bridge` 
+- If you are using the default `figwheel-bridge.js` provided by `clj-rn` (originally from `re-natal`), make sure that `cljsbuild` compiler options for `dev` environment look like this below:
+```
+{:ios
+   {:source-paths ["src"]
+    :compiler     {:output-to     "target/ios/index.js"
+                   :main          "env.ios.main"
+                   :output-dir    "target/ios"
+                   :optimizations :none
+                   :target        :nodejs}}
+   :android
+   {:source-paths ["src"]
+    :compiler     {:output-to     "target/android/index.js"
+                   :main          "env.android.main"
+                   :output-dir    "target/android"
+                   :optimizations :none
+                   :target        :nodejs}}}
+```
+Note: it also supports `:preloads` and `:closure-defines` options now thanks to the work done by `re-natal`.
+
+- Supported `figwheel-sidecar` version => `0.5.14`.
 
 ## Thanks
 

--- a/resources/figwheel-bridge.js
+++ b/resources/figwheel-bridge.js
@@ -1,0 +1,255 @@
+/*
+ * Originally taken from https://github.com/decker405/figwheel-react-native
+ *
+ * @providesModule figwheel-bridge
+ */
+
+var CLOSURE_UNCOMPILED_DEFINES = null;
+var debugEnabled = false;
+
+var config = {
+    basePath: "target/",
+    googBasePath: 'goog/',
+    serverPort: 8081
+};
+
+var React = require('react');
+var createReactClass = require('create-react-class');
+var ReactNative = require('react-native');
+var WebSocket = require('WebSocket');
+var self;
+var evaluate = eval; // This is needed, direct calls to eval does not work (RN packager???)
+var externalModules = {};
+var evalListeners = {};
+var asyncImportChain = new Promise(function (succ,fail) {succ(true);});
+
+function fireEvalListenters(url) {
+    Object.values(evalListeners).forEach(function (listener) {
+        listener(url)
+    });
+}
+
+function formatCompileError(msg) {
+    var errorStr = "Figwheel Compile Exception: "
+    var data = msg['exception-data'];
+    if(data['message']) {
+   	errorStr += data['message'] + " ";
+    }
+    if(data['file']) {
+   	errorStr += "in file " + data['file'] + " ";
+    }
+    if(data['line']) {
+   	errorStr += "at line " + data['line'];
+    }
+    if(data['column']) {
+   	errorStr += ", column " + data['column'];
+    }
+    return errorStr;
+}
+
+/* This is simply demonstrating that we can receive and react to 
+ * arbitrary messages from Figwheel this will enable creating a nicer
+ * feedback system in the Figwheel top level React component.
+ */
+function figwheelMessageHandler(msg) {
+    if(msg["msg-name"] == "compile-failed") {
+	console.warn(formatCompileError(msg));
+    }
+}
+
+function listenToFigwheelMessages() {
+    if(figwheel.client.add_json_message_watch) {
+	figwheel.client.add_json_message_watch("ReactNativeMessageIntercept",
+					       figwheelMessageHandler);
+    }
+}
+
+var figwheelApp = function (platform, devHost) {
+    return createReactClass({
+        getInitialState: function () {
+            return {loaded: false}
+        },
+        render: function () {
+            if (!this.state.loaded) {
+                var plainStyle = {flex: 1, alignItems: 'center', justifyContent: 'center'};
+                return (
+                    <ReactNative.View style={plainStyle}>
+                        <ReactNative.Text>Waiting for Figwheel to load files.</ReactNative.Text>
+                    </ReactNative.View>
+                );
+            }
+            return this.state.root;
+        },
+
+        componentDidMount: function () {
+            var app = this;
+            if (typeof goog === "undefined") {
+                loadApp(platform, devHost, function (appRoot) {
+                    app.setState({root: appRoot, loaded: true});
+		    listenToFigwheelMessages();
+                });
+            }
+        }
+    })
+};
+
+function logDebug(msg) {
+    if (debugEnabled) {
+        console.log(msg);
+    }
+}
+
+var isChrome = function () {
+    return typeof importScripts === "function"
+};
+
+function asyncImportScripts(url, success, error) {
+    logDebug('(asyncImportScripts) Importing: ' + url);
+    asyncImportChain =
+	asyncImportChain
+	.then(function (v) {return fetch(url);})
+        .then(function (response) {
+	    if(response.ok) 
+		return response.text();
+	    throw new Error("Failed to Fetch: " + url + " - Perhaps your project was cleaned and you haven't recompiled?")
+        })
+        .then(function (responseText) {
+	    evaluate(responseText);
+	    fireEvalListenters(url);
+            success();
+	    return true;
+        })
+        .catch(function (e) {
+            console.error(e);
+            error();
+	    return true;
+        });
+}
+
+function syncImportScripts(url, success, error) {
+    try {
+        importScripts(url);
+        logDebug('Evaluated: ' + url);
+	fireEvalListenters(url);
+        success();
+    } catch (e) {
+        console.error(e);
+        error()
+    }
+}
+
+// Loads js file sync if possible or async.
+function importJs(src, success, error) {
+    var noop = function(){};
+    success = (typeof success == 'function') ? success : noop;
+    error   = (typeof error   == 'function') ? error   : noop;
+    logDebug('(importJs) Importing: ' + src);
+    if (isChrome()) {
+        syncImportScripts(src, success, error);
+    } else {
+        asyncImportScripts(src, success, error);
+    }
+}
+
+function interceptRequire() {
+    var oldRequire = window.require;
+    console.info("Shimming require");
+    window.require = function (id) {
+        console.info("Requiring: " + id);
+        if (externalModules[id]) {
+            return externalModules[id];
+        }
+        return oldRequire(id);
+    };
+}
+
+function serverBaseUrl(host) {
+    return "http://" + host + ":" + config.serverPort
+}
+
+function isUnDefined(x) {
+    return typeof x == "undefined";
+}
+
+// unlikely to happen but it happened to me a couple of times so ...
+function assertRootElExists(platform) {
+    var basicMessage = "ClojureScript project didn't compile, or didn't load correctly.";
+    if(isUnDefined(env)) {
+	throw new Error("Critical Error: env namespace not defined - " + basicMessage);
+    } else if(isUnDefined(env[platform])) {
+	throw new Error("Critical Error: env." + platform + " namespace not defined - " + basicMessage);
+    } else if(isUnDefined(env[platform].main)) {
+	throw new Error("Critical Error: env." + platform + ".main namespace not defined - " + basicMessage);
+    } else if(isUnDefined(env[platform].main.root_el)) {
+	throw new Error("Critical Error: env." +
+			platform + ".main namespace doesn't define a root-el which should hold the root react node of your app.");
+    }
+ }
+
+function loadApp(platform, devHost, onLoadCb) {
+    var fileBasePath = serverBaseUrl((isChrome() ? "localhost" : devHost)) + "/" + config.basePath + platform;
+
+    // callback when app is ready to get the reloadable component
+    var mainJs = `/env/${platform}/main.js`;
+    evalListeners.waitForFinalEval = function (url) {
+        if (url.indexOf(mainJs) > -1) {
+	    assertRootElExists(platform);
+            onLoadCb(env[platform].main.root_el);
+            console.info('Done loading Clojure app');
+	    delete evalListeners.waitForFinalEval;
+        }
+    };
+
+    if (typeof goog === "undefined") {
+        console.info('Loading Closure base.');
+        interceptRequire();
+	// need to know base path here
+        importJs(fileBasePath + '/goog/base.js', function () {
+            shimBaseGoog(fileBasePath);
+            importJs(fileBasePath + '/cljs_deps.js');
+            importJs(fileBasePath + '/goog/deps.js', function () {
+                // This is needed because of RN packager
+                // seriously React packager? why.
+                var googreq = goog.require;
+
+                googreq(`env.${platform}.main`);
+            });
+        });
+    }
+}
+
+function startApp(appName, platform, devHost) {
+    ReactNative.AppRegistry.registerComponent(
+        appName, () => figwheelApp(platform, devHost));
+}
+
+function withModules(moduleById) {
+    externalModules = moduleById;
+    return self;
+}
+
+function figwheelImportScript(uri, callback) {
+    importJs(uri.toString(),
+	     function () {callback(true);},
+	     function () {callback(false);})
+}
+
+// Goog fixes
+function shimBaseGoog(basePath) {
+    console.info('Shimming goog functions.');
+    goog.basePath = basePath + '/' + config.googBasePath;
+    goog.global.FIGWHEEL_WEBSOCKET_CLASS = WebSocket;
+    goog.global.FIGWHEEL_IMPORT_SCRIPT = figwheelImportScript;
+    goog.writeScriptSrcNode = importJs;
+    goog.writeScriptTag_ = function (src, optSourceText) {
+        importJs(src);
+        return true;
+    };
+}
+
+self = {
+    withModules: withModules,
+    start: startApp
+};
+
+module.exports = self;

--- a/resources/figwheel-bridge.js
+++ b/resources/figwheel-bridge.js
@@ -4,7 +4,6 @@
  * @providesModule figwheel-bridge
  */
 
-var CLOSURE_UNCOMPILED_DEFINES = null;
 var debugEnabled = false;
 
 var config = {
@@ -33,34 +32,34 @@ function formatCompileError(msg) {
     var errorStr = "Figwheel Compile Exception: "
     var data = msg['exception-data'];
     if(data['message']) {
-   	errorStr += data['message'] + " ";
+        errorStr += data['message'] + " ";
     }
     if(data['file']) {
-   	errorStr += "in file " + data['file'] + " ";
+        errorStr += "in file " + data['file'] + " ";
     }
     if(data['line']) {
-   	errorStr += "at line " + data['line'];
+        errorStr += "at line " + data['line'];
     }
     if(data['column']) {
-   	errorStr += ", column " + data['column'];
+        errorStr += ", column " + data['column'];
     }
     return errorStr;
 }
 
-/* This is simply demonstrating that we can receive and react to 
+/* This is simply demonstrating that we can receive and react to
  * arbitrary messages from Figwheel this will enable creating a nicer
  * feedback system in the Figwheel top level React component.
  */
 function figwheelMessageHandler(msg) {
     if(msg["msg-name"] == "compile-failed") {
-	console.warn(formatCompileError(msg));
+        console.warn(formatCompileError(msg));
     }
 }
 
 function listenToFigwheelMessages() {
     if(figwheel.client.add_json_message_watch) {
-	figwheel.client.add_json_message_watch("ReactNativeMessageIntercept",
-					       figwheelMessageHandler);
+        figwheel.client.add_json_message_watch("ReactNativeMessageIntercept",
+            figwheelMessageHandler);
     }
 }
 
@@ -86,7 +85,7 @@ var figwheelApp = function (platform, devHost) {
             if (typeof goog === "undefined") {
                 loadApp(platform, devHost, function (appRoot) {
                     app.setState({root: appRoot, loaded: true});
-		    listenToFigwheelMessages();
+                    listenToFigwheelMessages();
                 });
             }
         }
@@ -103,34 +102,34 @@ var isChrome = function () {
     return typeof importScripts === "function"
 };
 
-function asyncImportScripts(url, success, error) {
+function asyncImportScripts(url, transform, success, error) {
     logDebug('(asyncImportScripts) Importing: ' + url);
     asyncImportChain =
-	asyncImportChain
-	.then(function (v) {return fetch(url);})
-        .then(function (response) {
-	    if(response.ok) 
-		return response.text();
-	    throw new Error("Failed to Fetch: " + url + " - Perhaps your project was cleaned and you haven't recompiled?")
-        })
-        .then(function (responseText) {
-	    evaluate(responseText);
-	    fireEvalListenters(url);
-            success();
-	    return true;
-        })
-        .catch(function (e) {
-            console.error(e);
-            error();
-	    return true;
-        });
+        asyncImportChain
+            .then(function (v) {return fetch(url);})
+            .then(function (response) {
+                if(response.ok)
+                    return response.text();
+                throw new Error("Failed to Fetch: " + url + " - Perhaps your project was cleaned and you haven't recompiled?")
+            })
+            .then(function (responseText) {
+                evaluate(transform(responseText));
+                fireEvalListenters(url);
+                success();
+                return true;
+            })
+            .catch(function (e) {
+                console.error(e);
+                error();
+                return true;
+            });
 }
 
 function syncImportScripts(url, success, error) {
     try {
         importScripts(url);
         logDebug('Evaluated: ' + url);
-	fireEvalListenters(url);
+        fireEvalListenters(url);
         success();
     } catch (e) {
         console.error(e);
@@ -141,13 +140,14 @@ function syncImportScripts(url, success, error) {
 // Loads js file sync if possible or async.
 function importJs(src, success, error) {
     var noop = function(){};
-    success = (typeof success == 'function') ? success : noop;
-    error   = (typeof error   == 'function') ? error   : noop;
+    var identity = function (arg){return arg};
+    var successCb = (typeof success == 'function') ? success : noop;
+    var errorCb = (typeof error   == 'function') ? error : noop;
     logDebug('(importJs) Importing: ' + src);
     if (isChrome()) {
-        syncImportScripts(src, success, error);
+        syncImportScripts(src, successCb, errorCb);
     } else {
-        asyncImportScripts(src, success, error);
+        asyncImportScripts(src, identity, successCb, errorCb);
     }
 }
 
@@ -175,16 +175,29 @@ function isUnDefined(x) {
 function assertRootElExists(platform) {
     var basicMessage = "ClojureScript project didn't compile, or didn't load correctly.";
     if(isUnDefined(env)) {
-	throw new Error("Critical Error: env namespace not defined - " + basicMessage);
+        throw new Error("Critical Error: env namespace not defined - " + basicMessage);
     } else if(isUnDefined(env[platform])) {
-	throw new Error("Critical Error: env." + platform + " namespace not defined - " + basicMessage);
+        throw new Error("Critical Error: env." + platform + " namespace not defined - " + basicMessage);
     } else if(isUnDefined(env[platform].main)) {
-	throw new Error("Critical Error: env." + platform + ".main namespace not defined - " + basicMessage);
+        throw new Error("Critical Error: env." + platform + ".main namespace not defined - " + basicMessage);
     } else if(isUnDefined(env[platform].main.root_el)) {
-	throw new Error("Critical Error: env." +
-			platform + ".main namespace doesn't define a root-el which should hold the root react node of your app.");
+        throw new Error("Critical Error: env." +
+            platform + ".main namespace doesn't define a root-el which should hold the root react node of your app.");
     }
- }
+}
+
+function importIndexJs(fileBasePath) {
+    var src = fileBasePath + '/index.js';
+    var transformFn = function(code) {
+        var defines = code.match(new RegExp ("goog.global.CLOSURE_UNCOMPILED_DEFINES.*?;"));
+        var deps = code.match(/goog.require\(.*?\);/g);
+        var transformedCode = defines.concat(deps).join('');
+        logDebug('transformed index.js: ', transformedCode);
+        return transformedCode;
+    };
+    logDebug('(importIndexJs) Importing: ' + src);
+    asyncImportScripts(src, transformFn, function(){}, function(){});
+}
 
 function loadApp(platform, devHost, onLoadCb) {
     var fileBasePath = serverBaseUrl((isChrome() ? "localhost" : devHost)) + "/" + config.basePath + platform;
@@ -193,26 +206,24 @@ function loadApp(platform, devHost, onLoadCb) {
     var mainJs = `/env/${platform}/main.js`;
     evalListeners.waitForFinalEval = function (url) {
         if (url.indexOf(mainJs) > -1) {
-	    assertRootElExists(platform);
+            assertRootElExists(platform);
             onLoadCb(env[platform].main.root_el);
             console.info('Done loading Clojure app');
-	    delete evalListeners.waitForFinalEval;
+            delete evalListeners.waitForFinalEval;
         }
     };
 
     if (typeof goog === "undefined") {
         console.info('Loading Closure base.');
         interceptRequire();
-	// need to know base path here
+
+        // need to know base path here
         importJs(fileBasePath + '/goog/base.js', function () {
             shimBaseGoog(fileBasePath);
-            importJs(fileBasePath + '/cljs_deps.js');
-            importJs(fileBasePath + '/goog/deps.js', function () {
-                // This is needed because of RN packager
-                // seriously React packager? why.
-                var googreq = goog.require;
-
-                googreq(`env.${platform}.main`);
+            importJs(fileBasePath + '/cljs_deps.js', function () {
+                importJs(fileBasePath + '/goog/deps.js', function () {
+                    importIndexJs(fileBasePath);
+                });
             });
         });
     }
@@ -230,8 +241,8 @@ function withModules(moduleById) {
 
 function figwheelImportScript(uri, callback) {
     importJs(uri.toString(),
-	     function () {callback(true);},
-	     function () {callback(false);})
+        function () {callback(true);},
+        function () {callback(false);})
 }
 
 // Goog fixes

--- a/src/clj_rn/specs.clj
+++ b/src/clj_rn/specs.clj
@@ -7,9 +7,12 @@
 ;;; config
 
 (s/def :config/main (s/merge (s/keys :req-un [:config/name]
-                                     :opt-un [:config/js-modules :config/resource-dirs])
-                             (s/map-of #{:name :js-modules :resource-dirs} any?)))
+                                     :opt-un [:config/js-modules
+                                              :config/resource-dirs
+                                              :config/figwheel-bridge])
+                             (s/map-of #{:name :js-modules :resource-dirs :figwheel-bridge} any?)))
 
 (s/def :config/name (and not-empty-string? #(re-matches #"^[A-Z][A-Za-z0-9]+$" %)))
 (s/def :config/js-modules (s/coll-of not-empty-string?))
 (s/def :config/resource-dirs (s/coll-of not-empty-string?))
+(s/def :config/figwheel-bridge not-empty-string?)


### PR DESCRIPTION
It now has a local copy of `figwheel-bridge.js` in `resources` dir that would be copied to `target/` dir of RN project every time when recreating `index.*.js`, then being loaded from `index.*.js`. You can specify your own `figwheel-bridge.js` by setting a value for `:figwheel-bridge` var in `clj-rn.conf.edn`.