### PR TITLE
[#1] Add watch task

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,55 +4,51 @@ A utility for building ClojureScript-based React Native apps
 
 ## Usage
 
-This small lib provides just some basic functionality that re-natal has: `enable-source-maps` and `rebuild-index`, which is equivalence of re-natal's `enable-source-maps`, `use-*-device`, `use-figwheel`.
+This small lib provides ability to start development with just one command and some basic functionality that re-natal has: `enable-source-maps` and `rebuild-index`, which is equivalence of re-natal's `enable-source-maps`, `use-*-device`, `use-figwheel`.
 
 ```
-clj -R:repl -m clj-rn.main help
+clj -R:dev -m clj-rn.main help
+
 enable-source-maps  Patches RN packager to server *.map files from filesystem, so that chrome can download them.
-rebuild-index       Generate index.*.js for development with figwheel
-help                Show this help
+rebuild-index      Generate index.*.js for development with figwheel
+watch             Start development
+help              Show this help
 ```
 
-`rebuild-index` has the following options:
+`watch` has the following options:
 ```
-clj -R:repl -m clj-rn.main rebuild-index --help
-  -p, --platform BUILD-IDS   [:android]  Platform Build IDs <android|ios>
-  -a, --android-device TYPE              Android Device Type <avd|genymotion|real>
-  -i, --ios-device TYPE                  iOS Device Type <simulator|real>
-      --figwheel-port PORT   3449        Figwheel Port
-  -h, --help
+clj -R:dev -m clj-rn.main watch -h
+
+-p, --platform BUILD-IDS [:android]  Platform Build IDs <android|ios>
+-a, --android-device TYPE           Android Device Type <avd|genymotion|real>
+-i, --ios-device TYPE              iOS Device Type <simulator|real>
+    --[no-]start-app               Start `react-native run-*` or not
+    --[no-]start-figwheel           Start Figwheel or not
+    --[no-]start-cljs-repl           Start cljs repl or not
+-h, --help
 ```
+
+## Setup re-natal project
+
+1. Create `deps.edn` file and add `clj-rn` as dependency. More about how to use git libraries here https://clojure.org/guides/deps_and_cli#_using_git_libraries
+2. Create `clj-rn.conf.edn`. See example [clj-rn.conf.example.edn](clj-rn.conf.example.edn)
+3. Run `clj -R:dev -m clj-rn.main watch -p ios -i simulator` to start development
 
 **Example usage**
 
 ```
-$ clj -R:repl -m clj-rn.main rebuild-index -p android,ios -a genymotion -i real --figwheel-port 3456
+$ clj -R:dev -m clj-rn.main watch -p android,ios -a genymotion -i real
 
 ```
 
-### Upgrading from an existing project
+## Possible config options
 
-- If your existing project has a `figwheel-bridge.js` in the root directory, it can be deleted now as `figwheel` task of `clj-rn.main` would create it for you and place it in `target` directory, it is being required by `index.*.js` every time when starting the app with figwheel. Alternatively, you can choose to use your own JS bridge by setting a variable named `:figwheel-bridge` in `clj-rn.conf.edn`, the value should be that of the JS module name. e.g. `./resources/bridge` 
-- If you are using the default `figwheel-bridge.js` provided by `clj-rn` (originally from `re-natal`), make sure that `cljsbuild` compiler options for `dev` environment look like this below:
-```
-{:ios
-   {:source-paths ["src"]
-    :compiler     {:output-to     "target/ios/index.js"
-                   :main          "env.ios.main"
-                   :output-dir    "target/ios"
-                   :optimizations :none
-                   :target        :nodejs}}
-   :android
-   {:source-paths ["src"]
-    :compiler     {:output-to     "target/android/index.js"
-                   :main          "env.android.main"
-                   :output-dir    "target/android"
-                   :optimizations :none
-                   :target        :nodejs}}}
-```
-Note: it also supports `:preloads` and `:closure-defines` options now thanks to the work done by `re-natal`.
-
-- Supported `figwheel-sidecar` version => `0.5.14`.
+- `:name` Name of your project. The same as in `package.json`
+- `:builds` Dev builds. You can copy it from `project.clj`
+- `:js-modules` List of all used libraries what is required like this `(js/require "...")`
+- `:resource-dirs` Folders with images and other resources
+- `:figwheel-bridge.js"` re-natal adds this file when you init project. If you don't have it, you can skip this options
+- `:figwheel-options` options for fegwheel server. List of all options https://github.com/bhauman/lein-figwheel/blob/0f62d6d043abb6156393fd167f6c1496c5439689/sidecar/resources/conf-fig-docs/FigwheelOptions.txt
 
 ## Thanks
 

--- a/clj-rn.conf.example.edn
+++ b/clj-rn.conf.example.edn
@@ -1,0 +1,29 @@
+{:name "CljRnExample"
+
+ ;; dev builds from project.clj
+ :builds [{:id           :ios
+           :source-paths ["src" "env/dev"]
+           :figwheel     true
+           :compiler     {:output-to     "target/ios/app.js"
+                          :main          "env.ios.main"
+                          :output-dir    "target/ios"
+                          :optimizations :none}}
+          {:id           :android
+           :source-paths ["src" "env/dev"]
+           :figwheel     true
+           :compiler     {:output-to     "target/android/app.js"
+                          :main          "env.android.main"
+                          :output-dir    "target/android"
+                          :optimizations :none}}]
+
+ :js-modules ["realm"]
+ :resource-dirs  ["images"]
+
+ ;; Don't set it if you don't have this file in your repo
+ :figwheel-bridge "figwheel-bridge.js"
+
+ ;; All options https://github.com/bhauman/lein-figwheel/blob/0f62d6d043abb6156393fd167f6c1496c5439689/sidecar/resources/conf-fig-docs/FigwheelOptions.txt
+ :figwheel-options {:nrepl-port 7888
+                    :nrepl-middleware ["cider.nrepl/cider-middleware"
+                                       "refactor-nrepl.middleware/wrap-refactor"
+                                       "cemerick.piggieback/wrap-cljs-repl"]}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,2 +1,4 @@
-{:deps  {org.clojure/tools.cli {:mvn/version "0.3.7"}}
- :paths ["src" "resources"]}
+{:paths ["src" "resources"]
+ :deps  {org.clojure/tools.cli {:mvn/version "0.3.7"}
+         figwheel-sidecar      {:mvn/version "0.5.16"
+                                :exclusions  [com.google.javascript/closure-compiler]}}}

--- a/src/clj_rn/main.clj
+++ b/src/clj_rn/main.clj
@@ -1,30 +1,16 @@
 (ns clj-rn.main
   (:require [clj-rn.core :as core]
             [clj-rn.shell :as shell]
-            clj-rn.specs
             [clj-rn.utils :as utils]
-            [clojure.edn :as edn]
-            [clojure.java.io :as io]
-            [clojure.spec.alpha :as spec]
             [clojure.string :as str]
             [clojure.tools.cli :as cli]))
 
-(defn get-main-config []
-  (try
-    (let [usr-config-file "clj-rn.conf.edn"]
-      (when-not (.isFile (io/as-file usr-config-file))
-        (throw (Exception. "Please create a clj-rn.conf.edn config file")))
-      (let [config (edn/read-string (slurp usr-config-file))]
-       (when-not (spec/valid? :config/main config)
-         (throw (Exception. "Invalid config.")))
-       config))
-    (catch Exception e
-      (utils/println-colorized (.getMessage e) shell/color-red)
-      (System/exit 1))))
+;;; Helper functions.
 
 (def cli-tasks-info
   {:enable-source-maps {:desc "Patches RN packager to server *.map files from filesystem, so that chrome can download them."}
    :rebuild-index      {:desc "Generate index.*.js for development with figwheel"}
+   :watch              {:desc "Start development"}
    :help               {:desc "Show this help"}})
 
 (defn- show-help []
@@ -40,13 +26,37 @@
            println)
       (println))))
 
-(defn parse-cli-opts [args opts]
-  (let [{:keys [options errors summary]} (cli/parse-opts args opts)]
+(defn print-and-exit [msg]
+  (println msg)
+  (System/exit 1))
+
+(defn parse-cli-options [args options]
+  (let [{:keys [options errors summary]} (cli/parse-opts args options)]
     (cond
-      (:help options)     (do (println summary)
-                              (System/exit 1))
-      (not (nil? errors)) (utils/log-err errors)
+      (:help options)     (print-and-exit summary)
+      (not (nil? errors)) (print-and-exit errors)
       :else               options)))
+
+(def common-options
+  [["-p" "--platform BUILD-IDS" "Platform Build IDs <android|ios>"
+    :id       :build-ids
+    :default  [:android]
+    :parse-fn #(->> (.split % ",")
+                    (map (comp keyword str/lower-case str/trim))
+                    vec)
+    :validate [(fn [build-ids] (every? #(some? (#{:android :ios} %)) build-ids)) "Must be \"android\", and/or \"ios\""]]
+   ["-a" "--android-device TYPE" "Android Device Type <avd|genymotion|real>"
+    :id       :android-device
+    :parse-fn #(keyword (str/lower-case %))
+    :validate [#(some? (#{:avd :genymotion :real} %)) "Must be \"avd\", \"genymotion\", or \"real\""]]
+   ["-i" "--ios-device TYPE" "iOS Device Type <simulator|real>"
+    :id       :ios-device
+    :parse-fn #(keyword (str/lower-case %))
+    :validate [#(some? (#{:simulator :real} %)) "Must be \"simulator\", or \"real\""]]])
+
+(defn with-common-options
+  [options]
+  (concat common-options options [["-h" "--help"]]))
 
 ;;; Task dispatching
 
@@ -67,57 +77,39 @@
 (defmethod task :enable-source-maps [_]
   (core/enable-source-maps))
 
-(def rebuild-index-task-opts
-  [["-p" "--platform BUILD-IDS" "Platform Build IDs <android|ios>"
-    :id       :build-ids
-    :default  [:android]
-    :parse-fn #(->> (.split % ",")
-                    (map (comp keyword str/lower-case str/trim))
-                    vec)
-    :validate [(fn [build-ids] (every? #(some? (#{:android :ios} %)) build-ids)) "Must be \"android\", and/or \"ios\""]]
-   ["-a" "--android-device TYPE" "Android Device Type <avd|genymotion|real>"
-    :id       :android-device
-    :parse-fn #(keyword (str/lower-case %))
-    :validate [#(some? (#{:avd :genymotion :real} %)) "Must be \"avd\", \"genymotion\", or \"real\""]]
-   ["-i" "--ios-device TYPE" "iOS Device Type <simulator|real>"
-    :id       :ios-device
-    :parse-fn #(keyword (str/lower-case %))
-    :validate [#(some? (#{:simulator :real} %)) "Must be \"simulator\", or \"real\""]]
-   [nil "--figwheel-port PORT" "Figwheel Port"
-    :id       :figwheel-port
-    :default  3449
-    :parse-fn #(Integer/parseInt %)
-    :validate [#(< 0 % 0x10000) "Must be a number between 0 and 65536"]]
-   ["-h" "--help"]])
+;;; :rebuild-index task
+
+(def rebuild-index-task-options
+  (with-common-options
+    [[nil "--figwheel-port PORT" "Figwheel Port"
+      :id       :figwheel-port
+      :default  3449
+      :parse-fn #(Integer/parseInt %)
+      :validate [#(< 0 % 0x10000) "Must be a number between 0 and 65536"]]]))
 
 (defmethod task :rebuild-index [[_ & args]]
   (let [{:keys [build-ids
                 android-device
                 ios-device
-                figwheel-port]}   (parse-cli-opts args rebuild-index-task-opts)
+                figwheel-port]}   (parse-cli-options args rebuild-index-task-options)
         hosts-map                 {:android (core/resolve-dev-host :android android-device)
-                                   :ios     (core/resolve-dev-host :ios ios-device)}
-        {:keys [name
-                js-modules
-                resource-dirs
-                figwheel-bridge]} (get-main-config)]
-    (when-not figwheel-bridge
-     (core/copy-figwheel-bridge))
+                                   :ios     (core/resolve-dev-host :ios ios-device)}]
     (core/write-env-dev hosts-map figwheel-port)
-    (doseq [build-id build-ids
-            :let     [host-ip       (get hosts-map build-id)
-                      platform-name (if (= build-id :ios) "iOS" "Android")]]
-      (core/rebuild-index-js build-id {:app-name        name
-                                       :host-ip         host-ip
-                                       :js-modules      js-modules
-                                       :resource-dirs   resource-dirs
-                                       :figwheel-bridge figwheel-bridge})
-      (when (= build-id :ios)
-        (core/update-ios-rct-web-socket-executor host-ip)
-        (utils/log "Host in RCTWebSocketExecutor.m was updated"))
-      (utils/log (format "Dev server host for %s: %s" platform-name host-ip)))))
+    (core/rebuild-index-files build-ids hosts-map)))
 
-;;; Help
+;;; :watch task
+
+(def watch-task-options
+  (with-common-options
+    [[nil "--[no-]start-app" "Start `react-native run-*` or not" :default true]
+     [nil "--[no-]start-figwheel" "Start Figwheel or not" :default true]
+     [nil "--[no-]start-cljs-repl" "Start cljs repl or not" :default true]]))
+
+(defmethod task :watch [[_ & args]]
+  (let [options (parse-cli-options args watch-task-options)]
+    (core/watch options)))
+
+;;; :help task
 
 (defmethod task :help [_]
   (show-help)

--- a/src/clj_rn/shell.clj
+++ b/src/clj_rn/shell.clj
@@ -1,6 +1,16 @@
-(ns clj-rn.shell)
+(ns clj-rn.shell
+  (:require [clojure.string :as str]
+            [clojure.java.io :as io])
+  (:import  java.lang.Runtime))
 
 (def color-reset "\u001b[0m")
 (def color-red "\u001b[31m")
 (def color-green "\u001b[32m")
 (def color-yellow "\u001b[33m")
+
+(defn exec
+  [command]
+  (let [process (.exec (Runtime/getRuntime) (into-array (str/split command #" ")))]
+    (with-open [reader (io/reader (.getInputStream process))]
+      (doseq [line (line-seq reader)]
+        (println line)))))

--- a/src/clj_rn/specs.clj
+++ b/src/clj_rn/specs.clj
@@ -6,13 +6,22 @@
 
 ;;; config
 
-(s/def :config/main (s/merge (s/keys :req-un [:config/name]
+(s/def :config/main (s/merge (s/keys :req-un [:config/name
+                                              :config/builds]
                                      :opt-un [:config/js-modules
                                               :config/resource-dirs
-                                              :config/figwheel-bridge])
-                             (s/map-of #{:name :js-modules :resource-dirs :figwheel-bridge} any?)))
+                                              :config/figwheel-bridge
+                                              :config/figwheel-options])
+                             (s/map-of #{:name
+                                         :js-modules
+                                         :resource-dirs
+                                         :figwheel-bridge
+                                         :figwheel-options
+                                         :builds} any?)))
 
 (s/def :config/name (and not-empty-string? #(re-matches #"^[A-Z][A-Za-z0-9]+$" %)))
 (s/def :config/js-modules (s/coll-of not-empty-string?))
 (s/def :config/resource-dirs (s/coll-of not-empty-string?))
 (s/def :config/figwheel-bridge not-empty-string?)
+(s/def :config/figwheel-options map?)
+(s/def :config/builds (s/coll-of map?))


### PR DESCRIPTION
fixes #1

### Summary:
Add watch task. This task starts react native packager, figwheel, repl and then run build. Also add new configs `:figwheel-options` and `:builds`.

### Review notes:
Example project https://github.com/endenwer/clj-rn-example. 
Commit https://github.com/endenwer/clj-rn-example/commit/4009e6fc2797f571f6340f7249b1312074effba1 shows what should be done to setup re-natal project to use clj-rn.

### Testing notes (optional):
Clone example repo and follow "usage" section.

status: ready
