### PR TITLE
Add --start-bundler option to watch task

### DIFF
--- a/src/clj_rn/core.clj
+++ b/src/clj_rn/core.clj
@@ -198,7 +198,7 @@
     (System/exit 1)))
 
 (defn watch
-  [{:keys [build-ids android-device ios-device start-figwheel start-app start-cljs-repl]}]
+  [{:keys [build-ids android-device ios-device start-figwheel start-app start-cljs-repl start-bundler]}]
   (let [{:keys [figwheel-options builds] :as config} (get-main-config)
         hosts-map {:android (resolve-dev-host :android android-device)
                    :ios     (resolve-dev-host :ios ios-device)}]
@@ -206,7 +206,8 @@
     (enable-source-maps)
     (write-env-dev hosts-map)
     (rebuild-index-files build-ids hosts-map)
-    (execute-react-native-cli ["start"] true)
+    (when start-bundler
+      (execute-react-native-cli ["start"] true))
     (when start-figwheel
       (ra/start-figwheel!
        {:build-ids build-ids

--- a/src/clj_rn/main.clj
+++ b/src/clj_rn/main.clj
@@ -103,7 +103,8 @@
   (with-common-options
     [[nil "--[no-]start-app" "Start `react-native run-*` or not" :default true]
      [nil "--[no-]start-figwheel" "Start Figwheel or not" :default true]
-     [nil "--[no-]start-cljs-repl" "Start cljs repl or not" :default true]]))
+     [nil "--[no-]start-cljs-repl" "Start cljs repl or not" :default true]
+     [nil "--[no-]start-bundler" "Start RN bundler or not" :default true]]))
 
 (defmethod task :watch [[_ & args]]
   (let [options (parse-cli-options args watch-task-options)]


### PR DESCRIPTION
Add `--[no]start-bundler` option to control RN metro bundler to be started automatically by `watch` task or not.

I made this option enabled by default as other options to `watch` command are also enabled by default.

If we want to make them all disabled by default, i could do that in separate PR.