### PR TITLE
remove alias for resolving dependencies from usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A utility for building ClojureScript-based React Native apps
 This small lib provides ability to start development with just one command and some basic functionality that re-natal has: `enable-source-maps` and `rebuild-index`, which is equivalence of re-natal's `enable-source-maps`, `use-*-device`, `use-figwheel`.
 
 ```
-clj -R:dev -m clj-rn.main help
+clj -m clj-rn.main help
 
 enable-source-maps  Patches RN packager to server *.map files from filesystem, so that chrome can download them.
 rebuild-index      Generate index.*.js for development with figwheel
@@ -17,7 +17,7 @@ help              Show this help
 
 `watch` has the following options:
 ```
-clj -R:dev -m clj-rn.main watch -h
+clj -m clj-rn.main watch -h
 
 -p, --platform BUILD-IDS [:android]  Platform Build IDs <android|ios>
 -a, --android-device TYPE           Android Device Type <avd|genymotion|real>


### PR DESCRIPTION
...as there is no corresponding :dev alias in the .edn file

## Rationale
While there is a :dev alias within `status-react`, it seems like the intention is for the `clj-rn` tool to be used independently, and is it stands there are no aliases in the local deps.edn file in this repo so removing this flag from the usage command seems to simplify things. 

If it's implied the user would have a dev alias at the user, rather than project level, then I may be missing the role this flag is playing, but maybe we could shout that out if that's the case!

In any event, as the bootstrapping process for `status-react` looks to rely heavily on `clj-rn` and its default behavior, any clarity or comments around here would be greatly appreciated! Thanks!